### PR TITLE
(fix) Use HMAC for signatures

### DIFF
--- a/src/cookie.rs
+++ b/src/cookie.rs
@@ -5,6 +5,8 @@ use serialize::json::{Json, Null};
 use serialize::hex::ToHex;
 use crypto::digest::Digest;
 use crypto::sha2::Sha256;
+use crypto::mac::Mac;
+use crypto::hmac::Hmac;
 
 /// The parsed cookie.
 ///
@@ -33,16 +35,15 @@ impl Cookie {
 
     /// Encode your signature
     ///
-    /// Signatures will be encoded with SHA-256.
+    /// Signatures will be authenticated with HMAC SHA-256.
     pub fn sign(&self, value: &String) -> Option<String> {
         match self.secret {
             Some(ref secret) => {
-                let mut sha = Sha256::new();
-                sha.input(secret.as_bytes());
-                sha.input(value.as_bytes());
+                let mut hmac = Hmac::new(Sha256::new(), secret.as_bytes());
+                hmac.input(value.as_bytes());
 
                 let hash: &mut [u8] = [0, ..32];
-                sha.result(hash);
+                hmac.raw_result(hash);
                 Some(hash.as_slice().to_hex())
             },
             None             => None

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -191,10 +191,10 @@ mod test {
 
     #[test]
     fn check_signature() {
-        // The signature should be a SHA-256 hash of @zzmpthung
+        // The signature should be the HMAC-SHA256 hash of key "@zzmp" and message "thung"
         let mut alloy = Alloy::new();
         let cookie = get_cookie(Some("@zzmp".to_string()),
-                                "thing=s:thung.2bc9a8b82a4a393ab67b2b8aaff0e3ab33cb4aca05ef4a0ba201141fbb029f42".to_string(),
+                                "thing=s:thung.e99abddcf60cad18f8d4b993efae53e81410cf2b2855af0309f1ae46fa527fbb".to_string(),
                                 &mut alloy);
         let mut map = HashMap::new();
         map.insert("thing".to_string(),

--- a/src/response.rs
+++ b/src/response.rs
@@ -287,8 +287,8 @@ mod test {
     fn check_signature() {
         let headers = HeaderCollection::empty();
         assert_eq!(get_cookie(headers, Some("@zzmp".to_string()), "thing", "thung"),
-            // Hash of @zzmpthung, the SHA-256 signature of the signed cookie
-            "thing=s:thung.2bc9a8b82a4a393ab67b2b8aaff0e3ab33cb4aca05ef4a0ba201141fbb029f42".to_string());
+            // HMAC-SHA256 of key "@zzmp" and message "thung"
+            "thing=s:thung.e99abddcf60cad18f8d4b993efae53e81410cf2b2855af0309f1ae46fa527fbb".to_string());
     }
 
     #[test]


### PR DESCRIPTION
Using a plain SHA-256 hash for message authentication is vulnerable to length extension attacks. Use the secure HMAC construct from rust-crypto.

In addition to this, the signature comparison should be done in constant time. See https://github.com/DaGenix/rust-crypto/issues/90.

(I temporarily applied the patch from #20 to my branch for building. I'll rebase it out once it's merged.)
