### PR TITLE
(fix) Use fixed time eq check.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,6 @@
 #![feature(globs)]
 
 //! Cookie parsing/setting middleware for the [iron](https://github.com/iron/iron) framework.
-//!
-//! __Warning__: Signed cookies are checked with a `==` operation,
-//! which is not guaranteed to be fixed time.
-//! _This leaves cookies vulnerable to length extension attacks._
 
 extern crate time;
 extern crate rustc;


### PR DESCRIPTION
The problem had to do with named asm labels in the compiler: https://github.com/rust-lang/rust/issues/16378

This was fixed upstream, in https://github.com/DaGenix/rust-crypto/issues/97

Fixes #22 .
