### PR TITLE
Fix a minor build error.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ extern crate url;
 extern crate serialize;
 extern crate iron;
 extern crate http;
-extern crate "rust-crypto" as crypto;
+extern crate crypto;
 #[cfg(test)]
-extern crate "iron-test" as test;
+extern crate iron_test as test;
 
 pub use cookie::Cookie;
 pub use parser::CookieParser;


### PR DESCRIPTION
rust-crypto has changed names to just crypto, and Rust's extern crate syntax changed.